### PR TITLE
add: fswebcamで写真を撮る際に最初の5フレームを捨てるようオプションを追加

### DIFF
--- a/script/util/cap.py
+++ b/script/util/cap.py
@@ -12,7 +12,7 @@ if not os.path.exists(basedir):
 d = datetime.now().strftime("%Y%m%d%H%M%S")
 file_path = os.path.join(basedir, f'{d}.jpg', )
 
-cp = subprocess.run(['fswebcam', '-r', cap_resolution, file_path])
+cp = subprocess.run(['fswebcam', '--skip', '5', '-r', cap_resolution, file_path])
 if cp.returncode != 0:
     sys.exit(1)
 


### PR DESCRIPTION
Webカメラを変更したところ微妙にピントがずれるため、skipオプションを追加し最初の5フレームを捨てることで安定させるように変更。

```
       -S, --skip <number>
              Set the number of frames to skip. These frames will be captured but won't be use. Use this  option
              if your camera sends some bad or corrupt frames when it first starts capturing.

              Default is "0".
```

https://manpages.ubuntu.com/manpages/bionic/man1/fswebcam.1.html